### PR TITLE
Minor make fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -145,6 +145,11 @@
 # check and adjust lib/env.mk and lib/config.mk
 
 include lib/env.mk
+
+.PHONY: install
+install: install-prerequisites
+# If we need prerequisites, that has to happen before including eg. config.mk
+
 include lib/config.mk
 
 # load model-specific configuration parameters
@@ -175,8 +180,6 @@ all: ${WORKDIR}/config.mk
 	${MAKE} eval
 	${MAKE} compare
 
-.PHONY: install
-install: install-prerequisites
 
 
 #---------------------------------------------------------------------

--- a/lib/env.mk
+++ b/lib/env.mk
@@ -166,7 +166,7 @@ TOKENIZER    = ${MOSESSCRIPTS}/tokenizer
 SUBWORD_BPE  ?= ${shell which subword-nmt 2>/dev/null || echo ${TOOLSDIR}/subword-nmt/subword_nmt/subword_nmt.py}
 SUBWORD_HOME ?= ${dir ${SUBWORD_BPE}}
 ifeq (${shell which subword-nmt},)
-  BPE_LEARN ?= pyhton3 ${SUBWORD_HOME}/learn_bpe.py
+  BPE_LEARN ?= python3 ${SUBWORD_HOME}/learn_bpe.py
   BPE_APPLY ?= python3 ${SUBWORD_HOME}/apply_bpe.py
 else
   BPE_LEARN ?= ${SUBWORD_BPE} learn-bpe


### PR DESCRIPTION
There are two commits here, one of which is just a typo fix, the other I'm not sure about. Should have made two branches I guess.. The problem is that variable definitions in eg. lib/config.mk use many of the commands defined in lib/env.mk and that are built there in the case of make install. So to avoid that failing, the make install target needs to be defined first. Or maybe it should be in lib/env.mk itself? make install still fails for me, but this is one step.