### PR TITLE
Marian compilation: max 8 jobs to avoid memory error

### DIFF
--- a/lib/env.mk
+++ b/lib/env.mk
@@ -285,7 +285,7 @@ ${TOOLSDIR}/jq/jq:
 ${TOOLSDIR}/marian-dev/build/marian: ${PROTOC}
 	mkdir -p ${dir $@}
 	cd ${dir $@} && cmake -DUSE_SENTENCEPIECE=on ${MARIAN_BUILD_OPTIONS} ..
-	${MAKE} -C ${dir $@} -j
+	${MAKE} -C ${dir $@} -j8
 
 ${TOOLSDIR}/protobuf/bin/protoc:
 	cd tools && git clone https://github.com/protocolbuffers/protobuf.git


### PR DESCRIPTION
On a machine with 12GB of RAM, `make install` was failing for me because marian compilation was exhausting the memory. In [their install instructions](https://marian-nmt.github.io/docs/) marian recommends limiting the number of make jobs to 4, while in `lib/env.mk` the `-j` option allows an infinite amount of jobs to be created.

This PR limits the number of jobs during marian compilation to 8. Managed to `make install` this package on an 12GB Ubuntu 18.04 machine after this small edit.